### PR TITLE
Fix flow

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -9,45 +9,53 @@
     </head>
     <body>
         <div class="group">
-            <div>
-                <header class="box">
-                    <h1>{{ app.name }}</h1>
+            <header class="box left">
+                <h1>{{ app.name }}</h1>
 
-                    <img src="/images/php-elephant.jpg" alt="{{ app.name }}">
+                <img src="/images/php-elephant.jpg" alt="{{ app.name }}">
 
-                    {{ meetup.group.description | raw }}
+                {{ meetup.group.description | raw }}
 
-                    <ul class="list list--icons">
-                        <li>
-                            <a href="{{ app.meetup.url }}" class="genericon genericon-month">
-                                <span>Find us on Meetup</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="{{ app.twitter.url }}" class="genericon genericon-twitter">
-                                <span>Tweet us at @{{ app.twitter.user }}</span>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="{{ app.github.url }}" class="genericon genericon-github">
-                                <span>Fork this on GitHub</span>
-                            </a>
-                        </li>
-                    </ul>
-
-                    <div class="box__footer">
-                        <a href="{{ app.meetup.url }}/members" class="genericon genericon-user">
-                            {{- meetup.group.members }} {{ meetup.group.who | lower -}}
+                <ul class="list list--icons">
+                    <li>
+                        <a href="{{ app.meetup.url }}" class="genericon genericon-month">
+                            <span>Find us on Meetup</span>
                         </a>
+                    </li>
+                    <li>
+                        <a href="{{ app.twitter.url }}" class="genericon genericon-twitter">
+                            <span>Tweet us at @{{ app.twitter.user }}</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ app.github.url }}" class="genericon genericon-github">
+                            <span>Fork this on GitHub</span>
+                        </a>
+                    </li>
+                </ul>
 
-                        {% if meetup.group.rating is defined and meetup.group.rating.average > 3 %}
-                            <span class="genericon genericon-digg">
-                                {{ meetup.group.rating.average | round(1) }}/5 from {{ meetup.group.rating.count }} ratings
-                            </span>
-                        {% endif %}
-                    </div>
-                </header>
+                <div class="box__footer">
+                    <a href="{{ app.meetup.url }}/members" class="genericon genericon-user">
+                        {{- meetup.group.members }} {{ meetup.group.who | lower -}}
+                    </a>
 
+                    {% if meetup.group.rating is defined and meetup.group.rating.average > 3 %}
+                        <span class="genericon genericon-digg">
+                            {{ meetup.group.rating.average | round(1) }}/5 from {{ meetup.group.rating.count }} ratings
+                        </span>
+                    {% endif %}
+                </div>
+            </header>
+
+            <div class="right">
+                {{ render('/meetup/events') }}
+
+                {{ render('/twitter/tweets') }}
+
+                {{ render('/meetup/posts') }}
+            </div>
+
+            <div class="left">
                 <section class="contact box">
                     <header class="box__header">
                         <h2>Get in touch</h2>
@@ -80,12 +88,6 @@
 
                 {{ render('/meetup/sponsors') }}
             </div>
-
-            {{ render('/meetup/events') }}
-
-            {{ render('/twitter/tweets') }}
-
-            {{ render('/meetup/posts') }}
         </div>
         <script src="http://code.jquery.com/jquery-2.1.0.min.js"></script>
         <script src="/js/jquery.expander.min.js"></script>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -106,13 +106,13 @@ img {
 }
 
 @media (min-width: 600px) {
-    .group > div {
+    .left {
         float: left;
         width: 40%;
         margin-left: -1em;
     }
 
-    .events, .posts, .tweets {
+    .right {
         float: right;
         width: 60%;
         margin-right: -1em;


### PR DESCRIPTION
The markup is in totally the wrong order semantically, and on small devices (single column layout), the wrong content is at the top, sponsors and reviews is above events.

Should go
- Header
- Upcoming events
- Past events
- Twitter
- Posts
- The rest

Re-ordering it is simple enough but then the floating is all whack, "The rest", which is floated left, ends up in line with "Posts".

Suggestions? Masonry (bleugh)? CSS3 flow-whatever-it's-called? Something else?
