### PR TITLE
Remove gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,2 +1,0 @@
-require('coffee-script/register');
-require('./gulpfile.coffee');


### PR DESCRIPTION
Since Gulp 3.7, gulpfile.coffee is found and loaded automatically.
